### PR TITLE
Decrease rate limit for issue triage

### DIFF
--- a/.github/workflows/autotriage.md
+++ b/.github/workflows/autotriage.md
@@ -6,7 +6,7 @@ on:
     types: [opened]
   roles: all
 rate-limit:
-  max: 2
+  max: 1
   window: 60
 permissions:
   contents: read


### PR DESCRIPTION
Reduce the maximum rate limit for issue triage from 2 to 1.