### PR TITLE
ci: add version comments to pinned otel action SHAs

### DIFF
--- a/.github/workflows/observability_repository.yml
+++ b/.github/workflows/observability_repository.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: plengauer/opentelemetry-github/actions/instrument/repository@fb367b62aa357d505408babf57a5c29d5f000412
+      - uses: plengauer/opentelemetry-github/actions/instrument/repository@fb367b62aa357d505408babf57a5c29d5f000412 # v5.49.0
         env:
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}


### PR DESCRIPTION
Renovate can only recognise and update a SHA-pinned action reference when the version is present as a trailing comment. Some `plengauer/opentelemetry-github` references in this repo were pinned to a SHA with no comment, so Renovate has been leaving them behind.

This PR adds the missing `# vX.Y.Z` comments. **No SHA was changed** — every version was resolved from the git tag pointing at the already-pinned commit:

| SHA | Version | Files |
|---|---|---|
| `fb367b62aa357d505408babf57a5c29d5f000412` | `v5.49.0` | `observability_repository.yml` |

The diff is comment-only: every changed line is byte-identical to before apart from the appended ` # vX.Y.Z`.

Auto-generated gh-aw files (`*.lock.yml`, `agentics-maintenance.yml`) were deliberately left untouched — they are marked DO NOT EDIT and are regenerated on recompile.

(🤖 generated by Claude)